### PR TITLE
clean up the file stream on response end/close/finish

### DIFF
--- a/index.js
+++ b/index.js
@@ -97,6 +97,16 @@ exports.pipe = function (req, res, path, type, opt_cb) {
   } else {
     var file = fs.createReadStream(path, {start: range[0], end: range[1]});
 
+    var cleanupFileStream = function() {
+      file.close();
+    }
+
+    // the event emitted seems to change based on version of node.js
+    // 'close' is fired as of v6.11.5
+    res.on('close', cleanupFileStream); // https://stackoverflow.com/a/9021242
+    res.on('end', cleanupFileStream);  // https://stackoverflow.com/a/16897986
+    res.on('finish', cleanupFileStream); // https://stackoverflow.com/a/14093091 - https://stackoverflow.com/a/38057516
+
     if (!ext.length || !pipe_extensions[ext]) {
       var header = {
         'Content-Length': range[1],


### PR DESCRIPTION
After the server runs indefinitely, it eventually experiences the following error:

```
Error: EMFILE: too many open files
```

After inspecting the code, it seems some of the streams aren't cleaned up. This eventually leaves around unused file streams. This merge request cleans up those streams when the response ends. 

Note: In my research, it appears the event emitted at the end of the response is different based on the version of node. This merge request adds a listener for each of those events.