### PR TITLE
Handle file extension capitalized

### DIFF
--- a/index.js
+++ b/index.js
@@ -82,7 +82,7 @@ exports.pipe = function (req, res, path, type, opt_cb) {
 
   var range = getRange(req, total);
 
-  var ext = pathModule.extname(path);
+  var ext = pathModule.extname(path).toLowerCase();
   if (!type && ext && ext.length) {
     type = exts[ext];
   }


### PR DESCRIPTION
Convert file extension in lower case (e.g. "test.MP3" -> "mp3") in order to match with the list libs/exts.js.